### PR TITLE
Add missing IPFS transaction link

### DIFF
--- a/concepts/transaction-types/README.md
+++ b/concepts/transaction-types/README.md
@@ -36,6 +36,8 @@ In the following sections basic transaction types and their structure is present
 
 {% page-ref page="multisignature-transaction.md" %}
 
+{% page-ref page="ipfs-transaction.md" %}
+
 {% page-ref page="multipayment-transaction.md" %}
 
 {% page-ref page="delegate-resignation.md" %}


### PR DESCRIPTION
Hi!

IPFS transaction type is missing in the `Transaction Types` list.